### PR TITLE
fix: ignore old client go packages in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,10 @@
   ],
   "packageRules": [
     {
+      "matchPackageNames": ["k8s.io/client-go"],
+      "allowedVersions": "!/1\\.(4\\.0|5\\.0|5\\.1|5\\.2)$/"
+    },
+    {
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": "!/^0/",
       "automerge": true


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

## 📑 Description
* Ignores old client-go packages, as renovate tries to downgrade to v11

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [X] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
