### PR TITLE
feat: add additionalLabels to serviceMonitor

### DIFF
--- a/chart/operator/templates/controller-manager-metrics-monitor.yaml
+++ b/chart/operator/templates/controller-manager-metrics-monitor.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/created-by: k8sgpt-operator
     app.kubernetes.io/part-of: k8sgpt-operator
     control-plane: controller-manager
-  {{- include "chart.labels" . | nindent 4 }}
+    {{- include "chart.labels" . | nindent 4 }}
   {{- if .Values.serviceMonitor.additionalLabels }}
     {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
   {{- end }}

--- a/chart/operator/templates/controller-manager-metrics-monitor.yaml
+++ b/chart/operator/templates/controller-manager-metrics-monitor.yaml
@@ -9,6 +9,9 @@ metadata:
     app.kubernetes.io/part-of: k8sgpt-operator
     control-plane: controller-manager
   {{- include "chart.labels" . | nindent 4 }}
+  {{- if .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
+  {{- end }}
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/chart/operator/values.yaml
+++ b/chart/operator/values.yaml
@@ -1,5 +1,6 @@
 serviceMonitor:
-  enabled: false
+  enabled: true
+  additionalLabels: {}
 controllerManager:
   kubeRbacProxy:
     containerSecurityContext:

--- a/chart/operator/values.yaml
+++ b/chart/operator/values.yaml
@@ -1,5 +1,5 @@
 serviceMonitor:
-  enabled: true
+  enabled: false
   additionalLabels: {}
 controllerManager:
   kubeRbacProxy:


### PR DESCRIPTION
Closes #[364](https://github.com/k8sgpt-ai/k8sgpt/issues/364)

## 📑 Description
This PR is to add the ability to add your own labels to the service monitor. In my case I use the Prometheus operator therefore I need to add an additional label so it references my prometheus release which is:

```yaml
labels:
  release: kube-prometheus-stack
```

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
For the reviewer testing this, you can run these tests.

Scenario 1: Run helm chart with service monitor enabled is false

in the values.yaml, the serviceMonitor enabled is false as follows:
```yaml
serviceMonitor:
  enabled: false
```

Scenario 2: Run helm chart without the additional labels

in the values.yaml, only use the serviceMonitor enable is true as follows:
```yaml
serviceMonitor:
  enabled: true
```

 Scenario 3: Run helm chart with the additional labels

in the values.yaml, only use the serviceMonitor enable is true and add labels as follows:
```yaml
serviceMonitor:
  enabled: true
  additionalLabels:
    release: kube-prometheus-stack
```

To test the values run this command in the root directory:

```bash
helm install ./chart/operator--dry-run --devel --generate-name > manifests.yaml
```

Then look in the manifests.yaml file and search throught it (remember to delete it)