### PR TITLE
feat: add azureopenai backend

### DIFF
--- a/api/v1alpha1/k8sgpt_types.go
+++ b/api/v1alpha1/k8sgpt_types.go
@@ -30,9 +30,13 @@ type SecretRef struct {
 
 // K8sGPTSpec defines the desired state of K8sGPT
 type K8sGPTSpec struct {
-	Backend  string     `json:"backend,omitempty"`
-	BaseUrl  string     `json:"baseUrl,omitempty"`
+	// +kubebuilder:default:=openai
+	// +kubebuilder:validation:Enum=openai;localai;azureopenai
+	Backend string `json:"backend,omitempty"`
+	BaseUrl string `json:"baseUrl,omitempty"`
+	// +kubebuilder:default:=gpt-3.5-turbo
 	Model    string     `json:"model,omitempty"`
+	Engine   string     `json:"engine,omitempty"`
 	Secret   *SecretRef `json:"secret,omitempty"`
 	Version  string     `json:"version,omitempty"`
 	EnableAI bool       `json:"enableAI,omitempty"`

--- a/chart/operator/Chart.yaml
+++ b/chart/operator/Chart.yaml
@@ -26,7 +26,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.9   # x-release-please-version
+version: 0.0.10   # x-release-please-version
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/chart/operator/Chart.yaml
+++ b/chart/operator/Chart.yaml
@@ -31,4 +31,4 @@ version: 0.0.9   # x-release-please-version
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.9"    # x-release-please-version
+appVersion: "0.0.10"    # x-release-please-version

--- a/chart/operator/templates/k8sgpt-crd.yaml
+++ b/chart/operator/templates/k8sgpt-crd.yaml
@@ -36,12 +36,20 @@ spec:
             description: K8sGPTSpec defines the desired state of K8sGPT
             properties:
               backend:
+                default: openai
+                enum:
+                - openai
+                - localai
+                - azureopenai
                 type: string
               baseUrl:
                 type: string
               enableAI:
                 type: boolean
+              engine:
+                type: string
               model:
+                default: gpt-3.5-turbo
                 type: string
               noCache:
                 type: boolean

--- a/config/crd/bases/core.k8sgpt.ai_k8sgpts.yaml
+++ b/config/crd/bases/core.k8sgpt.ai_k8sgpts.yaml
@@ -36,12 +36,20 @@ spec:
             description: K8sGPTSpec defines the desired state of K8sGPT
             properties:
               backend:
+                default: openai
+                enum:
+                - openai
+                - localai
+                - azureopenai
                 type: string
               baseUrl:
                 type: string
               enableAI:
                 type: boolean
+              engine:
+                type: string
               model:
+                default: gpt-3.5-turbo
                 type: string
               noCache:
                 type: boolean

--- a/pkg/resources/k8sgpt.go
+++ b/pkg/resources/k8sgpt.go
@@ -16,6 +16,7 @@ package resources
 
 import (
 	"context"
+	err "errors"
 
 	"github.com/k8sgpt-ai/k8sgpt-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -231,6 +232,18 @@ func GetDeployment(config v1alpha1.K8sGPT) (*appsv1.Deployment, error) {
 		deployment.Spec.Template.Spec.Containers[0].Env = append(
 			deployment.Spec.Template.Spec.Containers[0].Env, baseUrl,
 		)
+	}
+	// Engine is required only when azureopenai is the ai backend
+	if config.Spec.Engine != "" && config.Spec.Backend == "azureopenai" {
+		engine := v1.EnvVar{
+			Name:  "K8SGPT_ENGINE",
+			Value: config.Spec.Engine,
+		}
+		deployment.Spec.Template.Spec.Containers[0].Env = append(
+			deployment.Spec.Template.Spec.Containers[0].Env, engine,
+		)
+	} else if config.Spec.Engine != "" && config.Spec.Backend != "azureopenai" {
+		return &appsv1.Deployment{}, err.New("Engine is supported only by azureopenai provider.")
 	}
 	return &deployment, nil
 }


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
Adding azureopenai backend and introduce kubebuilder markers to assign default values for `model=gpt-3.5-turbo` and `backend=openai`  
I've also added an evaluation on the backend accepted names to help users define their desired backend name

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
There is a reconcile error if a user tries to specify `engine` without having azureopenai as their backend.
example:
```Finished Reconciling K8sGPT with error: Engine is supported only by azureopenai provider.
2023-05-05T20:29:08+03:00	ERROR	Reconciler error	{"controller": "k8sgpt", "controllerGroup": "core.k8sgpt.ai", "controllerKind": "K8sGPT", "K8sGPT": {"name":"k8sgpt-sample","namespace":"kube-system"}, "namespace": "kube-system", "name": "k8sgpt-sample", "reconcileID": "5a08a085-610b-44f6-ada8-19f052aad6b3", "error": "Engine is supported only by azureopenai provider."}
```
