### PR TITLE
feat: add namespace selector for ServiceMonitor

### DIFF
--- a/chart/operator/templates/_helpers.tpl
+++ b/chart/operator/templates/_helpers.tpl
@@ -60,3 +60,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "k8sgpt-operator.namespace" -}}
+{{- default .Release.Namespace }}
+{{- end }}

--- a/chart/operator/templates/controller-manager-metrics-monitor.yaml
+++ b/chart/operator/templates/controller-manager-metrics-monitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "chart.fullname" . }}-controller-manager-metrics-monitor
+  namespace: {{ .Values.serviceMonitor.namespace | default (include "k8sgpt-operator.namespace" . ) }}
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/created-by: k8sgpt-operator
@@ -13,6 +14,11 @@ metadata:
     {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
   {{- end }}
 spec:
+  {{- if .Values.serviceMonitor.namespace }}
+  namespaceSelector:
+    matchNames:
+    - {{ include "k8sgpt-operator.namespace" . }}
+  {{- end }}
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     path: /metrics

--- a/chart/operator/values.yaml
+++ b/chart/operator/values.yaml
@@ -1,6 +1,8 @@
 serviceMonitor:
   enabled: false
   additionalLabels: {}
+  # The namespace where Prometheus expects to find the serviceMonitor
+  # namespace: ""
 grafanaDashboard:
   enabled: false
   folder:


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here --> #131 

## 📑 Description
<!-- Add a brief description of the pr -->
Add namespace selector and enable deployment of ServiceMonitor in different namespaces than the operator's release

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
