### PR TITLE
fix: compare the number of errors to update Results

### DIFF
--- a/pkg/resources/results.go
+++ b/pkg/resources/results.go
@@ -64,7 +64,7 @@ func CreateOrUpdateResult(ctx context.Context, c client.Client, res v1alpha1.Res
 		}
 		return CreatedResult, nil
 	}
-	if existing.Spec.Details == res.Spec.Details && reflect.DeepEqual(res.Labels, existing.Labels) {
+	if len(existing.Spec.Error) == len(res.Spec.Error) && reflect.DeepEqual(res.Labels, existing.Labels) {
 		existing.Status.LifeCycle = string(NoOpResult)
 		err := c.Status().Update(ctx, &existing)
 		return NoOpResult, err


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
Small PR to fix the way we decide to update the Result CR,
we compare the number of errors that are returned from K8sGPT -- `Spec.Details` may change although its context remains the same

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
