### PR TITLE
feat(operator): add namespace to grafanaDashboard

### DIFF
--- a/chart/operator/templates/grafana-k8sgpt-dashboard.yaml
+++ b/chart/operator/templates/grafana-k8sgpt-dashboard.yaml
@@ -11,12 +11,7 @@ metadata:
     app.kubernetes.io/part-of: k8sgpt-operator
   {{- include "chart.labels" . | nindent 4 }}
   name: k8sgpt-overview
-spec:
-  {{- if .Values.grafanaDashboard.namespace }}
-  namespaceSelector:
-    matchNames:
-      - {{ include "k8sgpt-operator.namespace" .}}
-  {{- end }}
+  namespace: {{ .Values.grafanaDashboard.namespace | default (include "k8sgpt-operator.namespace" .) }}
 data:
   k8sgpt-overview.json: |
 {{ .Files.Get "dashboards/k8sgpt-overview.json" | indent 4}}

--- a/chart/operator/templates/grafana-k8sgpt-dashboard.yaml
+++ b/chart/operator/templates/grafana-k8sgpt-dashboard.yaml
@@ -11,7 +11,12 @@ metadata:
     app.kubernetes.io/part-of: k8sgpt-operator
   {{- include "chart.labels" . | nindent 4 }}
   name: k8sgpt-overview
-  namespace: {{ .Values.grafanaDashboard.namespace }}
+spec:
+  {{- if .Values.grafanaDashboard.namespace }}
+  namespaceSelector:
+    matchNames:
+      - {{ include "k8sgpt-operator.namespace" .}}
+  {{- end }}
 data:
   k8sgpt-overview.json: |
 {{ .Files.Get "dashboards/k8sgpt-overview.json" | indent 4}}

--- a/chart/operator/templates/grafana-k8sgpt-dashboard.yaml
+++ b/chart/operator/templates/grafana-k8sgpt-dashboard.yaml
@@ -11,6 +11,7 @@ metadata:
     app.kubernetes.io/part-of: k8sgpt-operator
   {{- include "chart.labels" . | nindent 4 }}
   name: k8sgpt-overview
+  namespace: {{ .Values.grafanaDashboard.namespace }}
 data:
   k8sgpt-overview.json: |
 {{ .Files.Get "dashboards/k8sgpt-overview.json" | indent 4}}

--- a/chart/operator/values.yaml
+++ b/chart/operator/values.yaml
@@ -5,7 +5,8 @@ serviceMonitor:
   # namespace: ""
 grafanaDashboard:
   enabled: false
-  namespace: system
+  # The namespace where Grafana expects to find the dashboard
+  # namespace: ""
   folder:
     annotation: grafana_folder
     name: ai

--- a/chart/operator/values.yaml
+++ b/chart/operator/values.yaml
@@ -5,6 +5,7 @@ serviceMonitor:
   # namespace: ""
 grafanaDashboard:
   enabled: false
+  namespace: system
   folder:
     annotation: grafana_folder
     name: ai


### PR DESCRIPTION
Closes #138 

## 📑 Description
The `namespace` field has been added to the `grafanaDashboard` section of the `values.yaml` file. This allows the Grafana dashboard to be deployed to a specific namespace, which improves organization and separation of concerns.


## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

