### PR TITLE
feat: add K8sGPT Custom Resource name as a prefix to slack messages

### DIFF
--- a/pkg/sinks/slack.go
+++ b/pkg/sinks/slack.go
@@ -13,8 +13,8 @@ var _ ISink = (*SlackSink)(nil)
 
 type SlackSink struct {
 	Endpoint string
-	Client   Client
 	K8sGPT   string
+	Client   Client
 }
 
 type SlackMessage struct {


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
In order to avoid having multiple slack channels to forward messages from k8sgpt operator we add a prefix to our slack messages, so it's more transparent which k8sgpt deployment is responsible for each analysis report.
e.g naming your K8sGPT CR with the name of your clusters you can track down easier where the problem is located and using a single pane of glass aka a single slack channel.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
This was requested on slack and I think it adds value. Unfortunately is not yet feasible to discern the name of your K8s cluster from within  the cluster so there is no way to add it programmatically..
