### PR TITLE
fix: operator's cluster role permissions to match k8sgpt

### DIFF
--- a/chart/operator/templates/manager-rbac.yaml
+++ b/chart/operator/templates/manager-rbac.yaml
@@ -55,6 +55,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #248 #252  <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
This PR fixes the RBAC issues introduced in the 0.0.22 release.
Effectively K8s won't allow an SA to create cluster roles more permissive than its own cluster roles, 
so we match the permission which will be eventually set for the K8sgpt cluster role.
## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
I will create a new feature request to lift and shift all the RBAC related resources to Helm chart templates which will be more clear to the user what roles will be created by K8sGPT operator whilst avoiding this matching pattern between the two cluster roles