### PR TITLE
feat: results are labeled

### DIFF
--- a/pkg/resources/results.go
+++ b/pkg/resources/results.go
@@ -30,13 +30,21 @@ func MapResults(i integrations.Integrations, resultsSpec []v1alpha1.ResultSpec, 
 		name := strings.ReplaceAll(resultSpec.Name, "-", "")
 		name = strings.ReplaceAll(name, "/", "")
 		result := GetResult(resultSpec, name, namespace, backend)
+		labels := map[string]string{
+			"k8sgpts.k8sgpt.ai/name":      config.Name,
+			"k8sgpts.k8sgpt.ai/namespace": config.Namespace,
+		}
+		if config.Spec.AI != nil {
+			labels["k8sgpts.k8sgpt.ai/backend"] = config.Spec.AI.Backend
+		}
 		if backstageEnabled {
+			// add Backstage label
 			backstageLabel := i.BackstageLabel(resultSpec)
-			if len(backstageLabel) != 0 {
-				// add Backstage label
-				result.ObjectMeta.Labels = backstageLabel
+			for k, v := range backstageLabel {
+				labels[k] = v
 			}
 		}
+		result.SetLabels(labels)
 
 		rawResults[name] = result
 	}


### PR DESCRIPTION
Closes #263

## 📑 Description
The following PR labels the `Result` objects with some additional labels, such as:
- `k8sgpts.k8sgpt.ai/name`, referring to the `k8sgpt` resource's Name
- `k8sgpts.k8sgpt.ai/namespace`, referring to the `k8sgpt` resource's namespace
- if specified, `k8sgpts.k8sgpt.ai/backend`, referring to the `k8sgpt` used AI driver

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
N.R.