### PR TITLE
feat: add mattermost sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,19 @@ EOF
 
 </details>
 
+<details>
+<summary>sink (integrations) </summary>
+
+Optional parameters available for sink.  
+('type', 'webhook' are required parameters.)
+
+| tool       | channel | icon_url | username |
+|------------|---------|----------|----------|
+| Slack      |         |          |          |
+| Mattermost | ✔️       | ✔️        | ✔️        |
+
+</details>
+
 ## Helm values
 
 For details please see [here](chart/operator/values.yaml)

--- a/api/v1alpha1/k8sgpt_types.go
+++ b/api/v1alpha1/k8sgpt_types.go
@@ -64,9 +64,12 @@ type GCSBackend struct {
 }
 
 type WebhookRef struct {
-	// +kubebuilder:validation:Enum=slack
+	// +kubebuilder:validation:Enum=slack;mattermost
 	Type     string `json:"type,omitempty"`
 	Endpoint string `json:"webhook,omitempty"`
+	Channel  string `json:"channel,omitempty"`
+	UserName string `json:"username,omitempty"`
+	IconURL  string `json:"icon_url,omitempty"`
 }
 
 type AISpec struct {

--- a/chart/operator/templates/k8sgpt-crd.yaml
+++ b/chart/operator/templates/k8sgpt-crd.yaml
@@ -145,9 +145,16 @@ spec:
                 type: string
               sink:
                 properties:
+                  channel:
+                    type: string
+                  icon_url:
+                    type: string
                   type:
                     enum:
                     - slack
+                    - mattermost
+                    type: string
+                  username:
                     type: string
                   webhook:
                     type: string

--- a/config/crd/bases/core.k8sgpt.ai_k8sgpts.yaml
+++ b/config/crd/bases/core.k8sgpt.ai_k8sgpts.yaml
@@ -145,9 +145,16 @@ spec:
                 type: string
               sink:
                 properties:
+                  channel:
+                    type: string
+                  icon_url:
+                    type: string
                   type:
                     enum:
                     - slack
+                    - mattermost
+                    type: string
+                  username:
                     type: string
                   webhook:
                     type: string

--- a/pkg/sinks/mattermost.go
+++ b/pkg/sinks/mattermost.go
@@ -1,0 +1,107 @@
+package sinks
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/k8sgpt-ai/k8sgpt-operator/api/v1alpha1"
+)
+
+var _ ISink = (*MattermostSink)(nil)
+
+type MattermostSink struct {
+	Endpoint string
+	K8sGPT   string
+	Client   Client
+	Channel  string
+	UserName string
+	IconURL  string
+}
+
+type MattermostMessage struct {
+	Text        string       `json:"text"`
+	Channel     string       `json:"channel,omitempty"`
+	UserName    string       `json:"username,omitempty"`
+	IconURL     string       `json:"icon_url,omitempty"`
+	Attachments []attachment `json:"attachments"`
+}
+
+type attachment struct {
+	Text  string `json:"text"`
+	Color string `json:"color"`
+	Title string `json:"title"`
+}
+
+func buildMattermostMessage(kind, name, details, k8sgptCR, channel, username, iconURL string) MattermostMessage {
+	return MattermostMessage{
+		Text:     fmt.Sprintf(">*[%s] K8sGPT analysis of the %s %s*", k8sgptCR, kind, name),
+		Channel:  channel,
+		UserName: username,
+		IconURL:  iconURL,
+		Attachments: []attachment{
+			attachment{
+				Text:  details,
+				Color: "danger",
+				Title: "Report",
+			},
+		},
+	}
+}
+
+func (s *MattermostSink) Configure(config v1alpha1.K8sGPT, c Client) {
+	s.Endpoint = config.Spec.Sink.Endpoint
+	// If no value is given, the default value of the webhook is used
+	if config.Spec.Sink.Channel != "" {
+		s.Channel = config.Spec.Sink.Channel
+	}
+	// If no value is given, the default value of the webhook is used
+	if config.Spec.Sink.UserName != "" {
+		s.UserName = config.Spec.Sink.UserName
+	}
+	// If no value is given, the default value of the webhook is used
+	if config.Spec.Sink.IconURL != "" {
+		s.IconURL = config.Spec.Sink.IconURL
+	}
+	s.Client = c
+	// take the name of the K8sGPT Custom Resource
+	s.K8sGPT = config.Name
+}
+
+func (s *MattermostSink) Emit(results v1alpha1.ResultSpec) error {
+	details := ""
+	// If AI is set to False, Details will not have a value, so if it is empty, use the Error text.
+	if results.Details == "" && len(results.Error) > 0 {
+		for i, v := range results.Error {
+			details += fmt.Sprintf("%d. %s\n", i+1, v.Text)
+		}
+	} else {
+		details = results.Details
+	}
+	message := buildMattermostMessage(
+		results.Kind, results.Name, details, s.K8sGPT,
+		s.Channel, s.UserName, s.IconURL,
+	)
+	payload, err := json.Marshal(message)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPost, s.Endpoint, bytes.NewBuffer(payload))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.Client.hclient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to send report: %s", resp.Status)
+	}
+
+	return nil
+}

--- a/pkg/sinks/sinkreporter.go
+++ b/pkg/sinks/sinkreporter.go
@@ -16,7 +16,9 @@ func NewSink(sinkType string) ISink {
 	switch sinkType {
 	case "slack":
 		return &SlackSink{}
-		//Introduce more Sink Providers
+	//Introduce more Sink Providers
+	case "mattermost":
+		return &MattermostSink{}
 	default:
 		return &SlackSink{}
 	}


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #300

## 📑 Description

1. added mattermost sink
- support mattermost incoming webhook
2. added parameter on sink (K8sGPT API)
- `Channel` (Mattermost Optional Param)
- `Username`  (Mattermost Optional Param)
- `IconURL`  (Mattermost Optional Param)
- [Mattermost Docs](https://developers.mattermost.com/integrate/webhooks/incoming/)

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

1. Confirmed that no value is entered in the notification content when ai is set to `enable: false`.
(current Slack notifications may be notified with no value as well.)

<img width="968" alt="Screenshot 2024-01-01 at 8 05 19 PM" src="https://github.com/k8sgpt-ai/k8sgpt-operator/assets/27955845/6656eded-c2fe-41d8-b8c2-51870418251c">

Change to -> I tried to load error text when ai is enable: false.

<img width="959" alt="Screenshot 2024-01-01 at 8 05 08 PM" src="https://github.com/k8sgpt-ai/k8sgpt-operator/assets/27955845/1f4cadad-2fb9-4002-b510-244c04dcfd32">

3. E2E Test Contents
- test assets is [here](https://github.com/tozastation/k8sgpt-operator-contribute-asset/tree/main/issue-300/k8s)
  - deploy mattermost server
  - applying resources detected in k8sgpt 
  - confirmation of incoming notifications

ai.enable: false pattern

<img width="959" alt="Screenshot 2024-01-01 at 8 05 08 PM" src="https://github.com/k8sgpt-ai/k8sgpt-operator/assets/27955845/9e0b886e-b1a4-4d9e-afde-1c0f8ea897eb">

ai.enable: true pattern
<img width="980" alt="Screenshot 2024-01-01 at 9 17 42 PM" src="https://github.com/k8sgpt-ai/k8sgpt-operator/assets/27955845/a6c33d71-11ea-4499-9b11-d8c45b847a12">




