### PR TITLE
Support for IPv6 clusters

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -48,6 +48,8 @@ func NewClient(address string) (*Client, error) {
 
 func GenerateAddress(ctx context.Context, cli client.Client, k8sgptConfig *v1alpha1.K8sGPT) (string, error) {
 	var address string
+	var ip net.IP
+
 	if os.Getenv("LOCAL_MODE") != "" {
 		address = "localhost:8080"
 	} else {
@@ -58,7 +60,12 @@ func GenerateAddress(ctx context.Context, cli client.Client, k8sgptConfig *v1alp
 		if err != nil {
 			return "", nil
 		}
-		address = fmt.Sprintf("%s:%d", svc.Spec.ClusterIP, svc.Spec.Ports[0].Port)
+		ip = net.ParseIP(svc.Spec.ClusterIP)
+		if ip.To4() != nil {
+			address = fmt.Sprintf("%s:%d", svc.Spec.ClusterIP, svc.Spec.Ports[0].Port)
+		} else {
+			address = fmt.Sprintf("[%s]:%d", svc.Spec.ClusterIP, svc.Spec.Ports[0].Port)
+		}
 	}
 
 	fmt.Printf("Creating new client for %s\n", address)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -58,7 +58,7 @@ func GenerateAddress(ctx context.Context, cli client.Client, k8sgptConfig *v1alp
 		err := cli.Get(ctx, client.ObjectKey{Namespace: k8sgptConfig.Namespace,
 			Name: k8sgptConfig.Name}, svc)
 		if err != nil {
-			return "", nil
+			return "", err
 		}
 		ip = net.ParseIP(svc.Spec.ClusterIP)
 		if ip.To4() != nil {
@@ -74,6 +74,7 @@ func GenerateAddress(ctx context.Context, cli client.Client, k8sgptConfig *v1alp
 	if err != nil {
 		return "", err
 	}
+	defer conn.Close()
 
 	fmt.Printf("Connection established between %s and localhost with time out of %d seconds.\n", address, int64(1))
 	fmt.Printf("Remote Address : %s \n", conn.RemoteAddr().String())


### PR DESCRIPTION
No idea if this works.  This is literally my first Go code (my "hello world" but IPv6 attempt).

Closes #369

## 📑 Description

Detect if a `ClusterIP` is IPv6 or IPv4.  Choose the appropriate string format based on Go documentation.

https://pkg.go.dev/net

> A literal IPv6 address in hostport must be enclosed in square brackets, as in "[::1]:80", "[::1%lo0]:80".

I've tested locally that it compiles with `make`.  I've not done any extra testing beyond that.  My development environment is Ubuntu 22.04.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information

I've successfully run `make test` from [my development environment](https://github.com/samrocketman/goenv).

```bash
$ go version
go version go1.21.6 linux/amd64
```