### PR TITLE
docs: syntax issue in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,6 @@ EOF
 
 <summary>Amazon Bedrock</summary>
 
-</details>
 1. Install the operator from the [Installation](#installation) section.
 
 2. Create secret:
@@ -308,6 +307,8 @@ spec:
   version: v0.3.29
 EOF
 ```
+
+</details>
 
 <details>
 


### PR DESCRIPTION
## 📑 Description
There was a misplaced details block causing the Bedrock section not to function as expected.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information

