### PR TITLE
fix: rollback namespace bug

### DIFF
--- a/pkg/resources/results.go
+++ b/pkg/resources/results.go
@@ -22,7 +22,7 @@ const (
 )
 
 func MapResults(i integrations.Integrations, resultsSpec []v1alpha1.ResultSpec, config v1alpha1.K8sGPT) (map[string]v1alpha1.Result, error) {
-	namespace := config.Spec.TargetNamespace
+	namespace := config.Namespace
 	backend := config.Spec.AI.Backend
 	backstageEnabled := config.Spec.ExtraOptions != nil && config.Spec.ExtraOptions.Backstage.Enabled
 	rawResults := make(map[string]v1alpha1.Result)


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes #447 <!-- Issue # here -->
Also fix https://github.com/k8sgpt-ai/k8sgpt/issues/1116 and https://github.com/k8sgpt-ai/k8sgpt/issues/1107

## 📑 Description
<!-- Add a brief description of the pr -->
`Result`'s namespace field was being filled in incorrectly: it was previously being populated with the namespace from config, which was replaced with the targetNamespace of `k8sgpt` in this [PR](https://github.com/k8sgpt-ai/k8sgpt-operator/pull/399). However, most users don't specify a targetNamespace and this field is nil, causing an error.

Here's the fix, and how it's working again after the fix.
![CleanShot 2024-05-22 at 01 09 03@2x](https://github.com/k8sgpt-ai/k8sgpt-operator/assets/20140126/fa10f81d-5e0c-43ed-989c-8b1bd35f91eb)


## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
