### PR TITLE
fix: Stop reconciling if K8sGPT CR is not in the operator namespace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o manager m
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot as production
+FROM gcr.io/distroless/static:nonroot AS production
 
 LABEL org.opencontainers.image.source="https://github.com/k8sgpt-ai/k8sgpt-operator" \
     org.opencontainers.image.url="https://k8sgpt.ai" \

--- a/chart/operator/templates/deployment.yaml
+++ b/chart/operator/templates/deployment.yaml
@@ -79,6 +79,10 @@ spec:
           value: {{ quote .Values.kubernetesClusterDomain }}
         - name: OPERATOR_SINK_WEBHOOK_TIMEOUT_SECONDS
           value: {{ quote .Values.controllerManager.manager.sinkWebhookTimeout }}
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag
           | default .Chart.AppVersion }}
         livenessProbe:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -98,5 +98,10 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
+        env:
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
I accidentally applied `K8sGPT` CR to the default namespace while the operator was installed in another namespace. This causes the newly created deployment can't be scaled to the minimum replicas (sa `k8sgpt` not found).

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  generation: 1
  name: k8sgpt-local-ai
  namespace: default
...
status:
  conditions:
  - lastTransitionTime: "2024-07-23T05:32:23Z"
    lastUpdateTime: "2024-07-23T05:32:23Z"
    message: Deployment does not have minimum availability.
    reason: MinimumReplicasUnavailable
    status: "False"
    type: Available
  - lastTransitionTime: "2024-07-23T05:32:23Z"
    lastUpdateTime: "2024-07-23T05:32:23Z"
    message: 'pods "k8sgpt-local-ai-546d874f59-" is forbidden: error looking up service
      account default/k8sgpt: serviceaccount "k8sgpt" not found'
    reason: FailedCreate
    status: "True"
    type: ReplicaFailure
```

So I updated the controller-manager deployment env and added an early check before creating the needed resources in the reconciling process.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

Testing done:
<img width="948" alt="Screenshot 2024-07-23 at 15 32 35" src="https://github.com/user-attachments/assets/a660b736-cbeb-4d4d-9d10-71e1df089e69">
<img width="942" alt="Screenshot 2024-07-23 at 15 32 09" src="https://github.com/user-attachments/assets/ea075ada-d03a-470e-8000-f2f12661c46c">
