### PR TITLE
Replace fmt.Printf/Println with logr.logger

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // This is the client for communicating with the K8sGPT in cluster deployment
@@ -68,7 +69,9 @@ func GenerateAddress(ctx context.Context, cli client.Client, k8sgptConfig *v1alp
 		}
 	}
 
-	fmt.Printf("Creating new client for %s\n", address)
+	log := log.FromContext(ctx)
+	log.Info(fmt.Sprintf("Creating new client for %s", address))
+
 	// Test if the port is open
 	conn, err := net.DialTimeout("tcp", address, 1*time.Second)
 	if err != nil {
@@ -76,8 +79,8 @@ func GenerateAddress(ctx context.Context, cli client.Client, k8sgptConfig *v1alp
 	}
 	defer conn.Close()
 
-	fmt.Printf("Connection established between %s and localhost with time out of %d seconds.\n", address, int64(1))
-	fmt.Printf("Remote Address : %s \n", conn.RemoteAddr().String())
+	log.WithValues("Remote Address", conn.RemoteAddr().String()).
+		Info(fmt.Sprintf("Connection established between %s and localhost with time out of %d seconds.", address, int64(1)))
 
 	return address, nil
 }

--- a/pkg/client/integration.go
+++ b/pkg/client/integration.go
@@ -6,10 +6,11 @@ import (
 
 	rpc "buf.build/gen/go/k8sgpt-ai/k8sgpt/grpc/go/schema/v1/schemav1grpc"
 	schemav1 "buf.build/gen/go/k8sgpt-ai/k8sgpt/protocolbuffers/go/schema/v1"
+	"github.com/go-logr/logr"
 	"github.com/k8sgpt-ai/k8sgpt-operator/api/v1alpha1"
 )
 
-func (c *Client) AddIntegration(config *v1alpha1.K8sGPT) error {
+func (c *Client) AddIntegration(logger logr.Logger, config *v1alpha1.K8sGPT) error {
 
 	// Check if the integration is active already
 	client := rpc.NewServerServiceClient(c.conn)
@@ -22,7 +23,7 @@ func (c *Client) AddIntegration(config *v1alpha1.K8sGPT) error {
 	}
 
 	if resp.Trivy.Enabled == config.Spec.Integrations.Trivy.Enabled {
-		fmt.Println("Skipping trivy installation, already enabled")
+		logger.Info("Skipping trivy installation, already enabled")
 		return nil
 	}
 	// If the integration is inactive, make it active

--- a/pkg/resources/results.go
+++ b/pkg/resources/results.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type ResultOperation string
@@ -63,6 +64,7 @@ func GetResult(resultSpec v1alpha1.ResultSpec, name, namespace, backend string, 
 	}
 }
 func CreateOrUpdateResult(ctx context.Context, c client.Client, res v1alpha1.Result) (ResultOperation, error) {
+	log := log.FromContext(ctx)
 	var existing v1alpha1.Result
 	if err := c.Get(ctx, client.ObjectKey{Namespace: res.Namespace, Name: res.Name}, &existing); err != nil {
 		if !errors.IsNotFound(err) {
@@ -71,7 +73,7 @@ func CreateOrUpdateResult(ctx context.Context, c client.Client, res v1alpha1.Res
 		if err := c.Create(ctx, &res); err != nil {
 			return NoOpResult, err
 		}
-		fmt.Printf("Created result %s\n", res.Name)
+		log.Info(fmt.Sprintf("Created result %s", res.Name))
 		return CreatedResult, nil
 	}
 	if len(existing.Spec.Error) == len(res.Spec.Error) && reflect.DeepEqual(res.Labels, existing.Labels) {
@@ -89,6 +91,6 @@ func CreateOrUpdateResult(ctx context.Context, c client.Client, res v1alpha1.Res
 	if err := c.Status().Update(ctx, &existing); err != nil {
 		return NoOpResult, err
 	}
-	fmt.Printf("Updated result %s\n", res.Name)
+	log.Info(fmt.Sprintf("Updated result %s", res.Name))
 	return UpdatedResult, nil
 }


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
Replace `fmt.Printf/Println` with `logr.logger` for more structured and leveled logging.

```log
2024-07-31T18:33:05+08:00       INFO    controller-runtime.metrics      Metrics server is starting to listen    {"addr": ":8080"}
2024-07-31T18:33:05+08:00       INFO    setup   starting manager
2024-07-31T18:33:05+08:00       INFO    starting server {"path": "/metrics", "kind": "metrics", "addr": "[::]:8080"}
2024-07-31T18:33:05+08:00       INFO    Starting server {"kind": "health probe", "addr": "[::]:8081"}
2024-07-31T18:33:05+08:00       INFO    Starting EventSource    {"controller": "k8sgpt", "controllerGroup": "core.k8sgpt.ai", "controllerKind": "K8sGPT", "source": "kind source: *v1alpha1.K8sGPT"}
2024-07-31T18:33:05+08:00       INFO    Starting Controller     {"controller": "k8sgpt", "controllerGroup": "core.k8sgpt.ai", "controllerKind": "K8sGPT"}
2024-07-31T18:33:05+08:00       INFO    Starting workers        {"controller": "k8sgpt", "controllerGroup": "core.k8sgpt.ai", "controllerKind": "K8sGPT", "worker count": 1}
2024-07-31T18:33:05+08:00       INFO    Reconciling K8sGPT      {"controller": "k8sgpt", "controllerGroup": "core.k8sgpt.ai", "controllerKind": "K8sGPT", "K8sGPT": {"name":"k8sgpt-sample-localai","namespace":"k8sgpt-operator-system"}, "namespace": "k8sgpt-operator-system", "name": "k8sgpt-sample-localai", "reconcileID": "863bf79d-ce72-4e4e-8e01-a339bc5fb51e"}
2024-07-31T18:33:05+08:00       INFO    Finished Reconciling k8sGPT     {"controller": "k8sgpt", "controllerGroup": "core.k8sgpt.ai", "controllerKind": "K8sGPT", "K8sGPT": {"name":"k8sgpt-sample-localai","namespace":"k8sgpt-operator-system"}, "namespace": "k8sgpt-operator-system", "name": "k8sgpt-sample-localai", "reconcileID": "863bf79d-ce72-4e4e-8e01-a339bc5fb51e"}
```

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->

Testing done:
1. make build -> ok
2. make test -> ok
3. docker-buildx -> ok
