### PR TITLE
chore: this allows local mode development without deploying out a dum…

### DIFF
--- a/controllers/k8sgpt_controller.go
+++ b/controllers/k8sgpt_controller.go
@@ -17,6 +17,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -177,7 +178,7 @@ func (r *K8sGPTReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return r.finishReconcile(err, false)
 	}
 
-	if deployment.Status.ReadyReplicas > 0 {
+	if deployment.Status.ReadyReplicas > 0 || os.Getenv("LOCAL_MODE") != "" {
 
 		// Check the repo and version of the deployment image matches the repo and version set in the K8sGPT CR
 		imageURI := deployment.Spec.Template.Spec.Containers[0].Image


### PR DESCRIPTION
The purpose here is to allow you to run the local k8sgpt serve and local operator without putting a fake deployment in the cluster.

e.g., `LOCAL_MODE=on go run main.go` would bypass the deployment replica status count and connect to a `localhost:8080` k8sgpt client