### PR TITLE
chore: fix missing namespace in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ EOF
    you will be able to see the Results objects of the analysis after some minutes (if there are any issues in your cluster):
 
 ```bash
-❯ kubectl get results -o json | jq .
+❯ kubectl get results -n k8sgpt-operator-system -o json | jq .
 {
   "apiVersion": "v1",
   "items": [


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

After the https://github.com/k8sgpt-ai/k8sgpt-operator/pull/86, 
```
#  kubectl get results -o json | jq .
{
  "apiVersion": "v1",
  "items": [],
  "kind": "List",
  "metadata": {
    "resourceVersion": "",
    "selfLink": ""
  }
}
``` 
There is no result in the default namespace.
And in the `k8sgpt-operator-system` namespace, it can work, like:
```
# kubectl get results -n k8sgpt-operator-system
NAME              KIND      BACKEND   AGE
defaultdao2048    Service   openai    61m
defaultvllmlora   Service   openai    61m
```



<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
