### PR TITLE
Remove ProxyEndpoint hardcoded backend checks to allow usage of HTTP proxies in any backend

### DIFF
--- a/pkg/resources/k8sgpt.go
+++ b/pkg/resources/k8sgpt.go
@@ -496,8 +496,8 @@ func GetDeployment(config v1alpha1.K8sGPT, outOfClusterMode bool, c client.Clien
 		return &appsv1.Deployment{}, err.New("engine is supported only by azureopenai provider")
 	}
 
-	// ProxyEndpoint is required only when azureopenai or openai is the ai backend
-	if config.Spec.AI.ProxyEndpoint != "" && (config.Spec.AI.Backend == v1alpha1.AzureOpenAI || config.Spec.AI.Backend == v1alpha1.OpenAI) {
+	// Configure ProxyEndpoint env variable
+	if config.Spec.AI.ProxyEndpoint != "" {
 		proxyEndpoint := corev1.EnvVar{
 			Name:  "K8SGPT_PROXY_ENDPOINT",
 			Value: config.Spec.AI.ProxyEndpoint,
@@ -505,9 +505,6 @@ func GetDeployment(config v1alpha1.K8sGPT, outOfClusterMode bool, c client.Clien
 		deployment.Spec.Template.Spec.Containers[0].Env = append(
 			deployment.Spec.Template.Spec.Containers[0].Env, proxyEndpoint,
 		)
-	} else if config.Spec.AI.ProxyEndpoint != "" && config.Spec.AI.Backend != v1alpha1.AzureOpenAI && config.Spec.AI.Backend != v1alpha1.OpenAI {
-		return &appsv1.Deployment{}, err.New("proxyEndpoint is supported only by azureopenai and openai provider")
-
 	}
 
 	// Add checks for amazonbedrock


### PR DESCRIPTION
## 📑 Description
I propose that the hardcoded check in the operator to set the `K8SGPT_PROXY_ENDPOINT` environment variable gets removed, in other to allow it to be set in any backend. This gives flexibility and allows k8sgpt-operator users that are behind proxies to setup this variable to any backend (e.g. localai). 

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
In my use case I have a remote Ollama backend and I need to access it through a proxy. K8SGPT allows Ollama to have a proxy endpoint defined, reference https://github.com/k8sgpt-ai/k8sgpt/blob/d1a29e400168053cb7357701995e30ffb8640efb/pkg/ai/ollama.go#L51
