### PR TITLE
feat: sneaky little bug fix

### DIFF
--- a/api/v1alpha1/result_types.go
+++ b/api/v1alpha1/result_types.go
@@ -63,8 +63,9 @@ type ResultSpec struct {
 
 // ResultStatus defines the observed state of Result
 type ResultStatus struct {
-	LifeCycle string `json:"lifecycle,omitempty"`
-	Webhook   string `json:"webhook,omitempty"`
+	LifeCycle   string `json:"lifecycle,omitempty"`
+	Webhook     string `json:"webhook,omitempty"`
+	ContentHash string `json:"contentHash,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/chart/operator/templates/result-crd.yaml
+++ b/chart/operator/templates/result-crd.yaml
@@ -34,20 +34,31 @@ spec:
         description: Result is the Schema for the results API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
           spec:
             description: ResultSpec defines the desired state of Result
             properties:
+              autoRemediationStatus:
+                properties:
+                  phase:
+                    description: Enum for Phase
+                    type: integer
+                type: object
               backend:
                 type: string
               details:
@@ -75,6 +86,7 @@ spec:
               parentObject:
                 type: string
             required:
+            - autoRemediationStatus
             - backend
             - details
             - error
@@ -85,6 +97,8 @@ spec:
           status:
             description: ResultStatus defines the observed state of Result
             properties:
+              contentHash:
+                type: string
               lifecycle:
                 type: string
               webhook:
@@ -95,9 +109,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/core.k8sgpt.ai_results.yaml
+++ b/config/crd/bases/core.k8sgpt.ai_results.yaml
@@ -96,6 +96,8 @@ spec:
           status:
             description: ResultStatus defines the observed state of Result
             properties:
+              contentHash:
+                type: string
               lifecycle:
                 type: string
               webhook:


### PR DESCRIPTION
The Problem: The AI would generate slightly different wording for the same issue each time, causing the operator to think the result "changed" and send duplicate notifications every 30 seconds.

 We now hash the meaningful parts of each result (kind, name, parent object, error texts) and ignore the AI-generated details that naturally vary. If the hash is the same, we know it's the same issue → mark as "historical" → no notification sent.