### PR TITLE
docs: add documentation for filters and optional analyzers

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,100 @@ Optional parameters available for sink.
 
 </details>
 
+<details>
+<summary>Filters (Analyzers)</summary>
+
+The `filters` field allows you to specify which analyzers K8sGPT should use when scanning your cluster. By default, K8sGPT enables a set of core analyzers. You can use filters to enable additional optional analyzers or to restrict analysis to specific resource types.
+
+**Core Analyzers** (enabled by default):
+- Pod
+- Deployment
+- ReplicaSet
+- PersistentVolumeClaim
+- Service
+- Ingress
+- StatefulSet
+- Job
+- CronJob
+- Node
+- ValidatingWebhookConfiguration
+- MutatingWebhookConfiguration
+- ConfigMap
+
+**Optional Analyzers** (disabled by default):
+- HorizontalPodAutoscaler
+- PodDisruptionBudget
+- NetworkPolicy
+- Log
+- GatewayClass
+- Gateway
+- HTTPRoute
+
+**Important**: When you specify the `filters` field, it replaces the default analyzer list. To enable optional analyzers while keeping the defaults, you must explicitly list all the analyzers you want to use.
+
+Example - Enable Log and HPA analyzers along with some core analyzers:
+
+```sh
+kubectl apply -f - << EOF
+apiVersion: core.k8sgpt.ai/v1alpha1
+kind: K8sGPT
+metadata:
+  name: k8sgpt-sample
+  namespace: k8sgpt-operator-system
+spec:
+  ai:
+    enabled: true
+    model: gpt-4o-mini
+    backend: openai
+    secret:
+      name: k8sgpt-sample-secret
+      key: openai-api-key
+  noCache: false
+  repository: ghcr.io/k8sgpt-ai/k8sgpt
+  version: v0.4.1
+  filters:
+    - Pod
+    - Deployment
+    - Service
+    - ReplicaSet
+    - Ingress
+    - StatefulSet
+    - Job
+    - CronJob
+    - Node
+    - Log
+    - HorizontalPodAutoscaler
+EOF
+```
+
+Example - Analyze only Pods and Deployments:
+
+```sh
+kubectl apply -f - << EOF
+apiVersion: core.k8sgpt.ai/v1alpha1
+kind: K8sGPT
+metadata:
+  name: k8sgpt-sample
+  namespace: k8sgpt-operator-system
+spec:
+  ai:
+    enabled: true
+    model: gpt-4o-mini
+    backend: openai
+    secret:
+      name: k8sgpt-sample-secret
+      key: openai-api-key
+  noCache: false
+  repository: ghcr.io/k8sgpt-ai/k8sgpt
+  version: v0.4.1
+  filters:
+    - Pod
+    - Deployment
+EOF
+```
+
+</details>
+
 ## Helm values
 
 For details please see [here](chart/operator/values.yaml)

--- a/config/samples/exhaustive_sample.yaml
+++ b/config/samples/exhaustive_sample.yaml
@@ -23,7 +23,13 @@ spec:
         url: <analyzer-url>
         port: <analyzer-port>
   filters:                     # Filters for analysis (optional)
-    - <filter-expression>
+    # When specified, replaces the default analyzer list.
+    # Core analyzers (enabled by default): Pod, Deployment, ReplicaSet,
+    # PersistentVolumeClaim, Service, Ingress, StatefulSet, Job, CronJob,
+    # Node, ValidatingWebhookConfiguration, MutatingWebhookConfiguration, ConfigMap
+    # Optional analyzers: HorizontalPodAutoscaler, PodDisruptionBudget,
+    # NetworkPolicy, Log, GatewayClass, Gateway, HTTPRoute
+    - <analyzer-name>
   extraOptions:                 # Extra options (optional)
     backstage:
       enabled: <boolean>

--- a/config/samples/filters_example.yaml
+++ b/config/samples/filters_example.yaml
@@ -1,0 +1,46 @@
+# Example: Using filters to enable optional analyzers
+#
+# This example shows how to enable optional analyzers (Log, HorizontalPodAutoscaler)
+# along with a subset of core analyzers.
+#
+# Note: When you specify the filters field, it replaces the default analyzer list.
+# You must explicitly list all analyzers you want to use.
+#
+# Core Analyzers (enabled by default when filters is not specified):
+#   Pod, Deployment, ReplicaSet, PersistentVolumeClaim, Service, Ingress,
+#   StatefulSet, Job, CronJob, Node, ValidatingWebhookConfiguration,
+#   MutatingWebhookConfiguration, ConfigMap
+#
+# Optional Analyzers (disabled by default):
+#   HorizontalPodAutoscaler, PodDisruptionBudget, NetworkPolicy, Log,
+#   GatewayClass, Gateway, HTTPRoute
+apiVersion: core.k8sgpt.ai/v1alpha1
+kind: K8sGPT
+metadata:
+  name: k8sgpt-with-filters
+  namespace: k8sgpt-operator-system
+spec:
+  ai:
+    enabled: true
+    model: gpt-4o-mini
+    backend: openai
+    secret:
+      name: k8sgpt-sample-secret
+      key: openai-api-key
+  noCache: false
+  repository: ghcr.io/k8sgpt-ai/k8sgpt
+  version: v0.3.48
+  # Specify which analyzers to use
+  # This enables core analyzers plus Log and HPA optional analyzers
+  filters:
+    - Pod
+    - Deployment
+    - Service
+    - ReplicaSet
+    - StatefulSet
+    - Job
+    - CronJob
+    - Node
+    - Ingress
+    - Log
+    - HorizontalPodAutoscaler


### PR DESCRIPTION
## Summary

This PR adds documentation explaining how to use the `filters` field to enable optional analyzers such as `Log` (logAnalyzer) and `HorizontalPodAutoscaler` (hpaAnalyzer).

### Changes

- Add "Filters (Analyzers)" section to README.md containing:
  - List of core analyzers (enabled by default)
  - List of optional analyzers (disabled by default)
  - Explanation that specifying filters replaces the default analyzer list
  - Usage examples showing how to enable optional analyzers
- Update `config/samples/exhaustive_sample.yaml` with inline comments listing available analyzers
- Add new `config/samples/filters_example.yaml` sample file demonstrating filters usage

### Problem

Users were unable to determine how to enable optional analyzers like `logAnalyzer` or `hpaAnalyzer` when using the K8sGPT Operator. The existing documentation did not explain:
- What analyzers are available
- Which analyzers are enabled by default vs optional
- That specifying filters replaces the defaults rather than adding to them

Fixes #685

## Test plan

- [ ] Verify README.md renders correctly on GitHub
- [ ] Verify example YAML files are valid