### PR TITLE
feat: add HTTP mode support for k8sgpt deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ spec:
   #  namespace: trivy-system
   # filters:
   #   - Ingress
+  # http: false
   # sink:
   #   type: slack
   #   webhook: <webhook-url> # use the sink secret if you want to keep your webhook url private

--- a/api/v1alpha1/k8sgpt_types.go
+++ b/api/v1alpha1/k8sgpt_types.go
@@ -162,15 +162,17 @@ type K8sGPTSpec struct {
 	Resources        *corev1.ResourceRequirements `json:"resources,omitempty"`
 	NoCache          bool                         `json:"noCache,omitempty"`
 	CustomAnalyzers  []CustomAnalyzer             `json:"customAnalyzers,omitempty"`
-	Filters          []string                     `json:"filters,omitempty"`
-	ExtraOptions     *ExtraOptionsRef             `json:"extraOptions,omitempty"`
-	Sink             *WebhookRef                  `json:"sink,omitempty"`
-	AI               *AISpec                      `json:"ai,omitempty"`
-	RemoteCache      *RemoteCacheRef              `json:"remoteCache,omitempty"`
-	Integrations     *Integrations                `json:"integrations,omitempty"`
-	NodeSelector     map[string]string            `json:"nodeSelector,omitempty"`
-	TargetNamespace  string                       `json:"targetNamespace,omitempty"`
-	Analysis         *AnalysisConfig              `json:"analysis,omitempty"`
+	// +kubebuilder:default:=false
+	HTTP            bool              `json:"http,omitempty"`
+	Filters         []string          `json:"filters,omitempty"`
+	ExtraOptions    *ExtraOptionsRef  `json:"extraOptions,omitempty"`
+	Sink            *WebhookRef       `json:"sink,omitempty"`
+	AI              *AISpec           `json:"ai,omitempty"`
+	RemoteCache     *RemoteCacheRef   `json:"remoteCache,omitempty"`
+	Integrations    *Integrations     `json:"integrations,omitempty"`
+	NodeSelector    map[string]string `json:"nodeSelector,omitempty"`
+	TargetNamespace string            `json:"targetNamespace,omitempty"`
+	Analysis        *AnalysisConfig   `json:"analysis,omitempty"`
 	// Define the kubeconfig the Deployment must use.
 	// If empty, the Deployment will use the ServiceAccount provided by Kubernetes itself.
 	Kubeconfig *SecretRef `json:"kubeconfig,omitempty"`

--- a/chart/operator/templates/k8sgpt-crd.yaml
+++ b/chart/operator/templates/k8sgpt-crd.yaml
@@ -165,6 +165,9 @@ spec:
                 items:
                   type: string
                 type: array
+              http:
+                default: false
+                type: boolean
               imagePullPolicy:
                 description: PullPolicy describes a policy for if/when to pull a container
                   image

--- a/config/crd/bases/core.k8sgpt.ai_k8sgpts.yaml
+++ b/config/crd/bases/core.k8sgpt.ai_k8sgpts.yaml
@@ -163,6 +163,9 @@ spec:
                 items:
                   type: string
                 type: array
+              http:
+                default: false
+                type: boolean
               imagePullPolicy:
                 description: PullPolicy describes a policy for if/when to pull a container
                   image

--- a/pkg/resources/k8sgpt.go
+++ b/pkg/resources/k8sgpt.go
@@ -255,6 +255,11 @@ func buildK8sGPTArgs(config v1alpha1.K8sGPT) []string {
 		}
 	}
 
+	// Enable REST/http using gppc-gateway if specified in the configuration
+	if config.Spec.HTTP {
+		args = append(args, "--http")
+	}
+
 	return args
 }
 

--- a/pkg/resources/k8sgpt_test.go
+++ b/pkg/resources/k8sgpt_test.go
@@ -341,3 +341,61 @@ func Test_GetDeploymentWithFilters(t *testing.T) {
 		})
 	}
 }
+func Test_GetDeploymentWithHttpMode(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, v1.AddToScheme(scheme))
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	testCases := []struct {
+		name         string
+		httpEnabled  bool
+		expectedArgs []string
+	}{
+		{
+			name:         "HTTP mode disabled",
+			httpEnabled:  false,
+			expectedArgs: []string{"serve"},
+		},
+		{
+			name:         "HTTP mode enabled",
+			httpEnabled:  true,
+			expectedArgs: []string{"serve", "--http"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := v1alpha1.K8sGPT{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "K8sGPT",
+					APIVersion: "core.k8sgpt.ai/v1alpha1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-k8sgpt",
+					Namespace: "test-namespace",
+					UID:       "test-uid",
+				},
+				Spec: v1alpha1.K8sGPTSpec{
+					Repository:      "ghcr.io/k8sgpt-ai/k8sgpt",
+					Version:         "v0.4.1",
+					ImagePullPolicy: v1.PullAlways,
+					HTTP:            tc.httpEnabled,
+					AI: &v1alpha1.AISpec{
+						Backend:   "openai",
+						Model:     "gpt-4o-mini",
+						MaxTokens: "2048",
+						Topk:      "50",
+					},
+				},
+			}
+
+			deployment, err := GetDeployment(config, false, fakeClient, "test-sa")
+			require.NoError(t, err)
+
+			// Verify the args contain the expected values
+			assert.Equal(t, tc.expectedArgs, deployment.Spec.Template.Spec.Containers[0].Args,
+				"Expected args to match for HTTP mode: %v", tc.httpEnabled)
+		})
+	}
+}


### PR DESCRIPTION
- Add HTTP field to K8sGPTSpec struct
- Update CRD definitions to include http boolean field
- Implement --http flag in k8sgpt deployment args when HTTP is enabled
- Add comprehensive unit tests for HTTP mode functionality
- Update README with HTTP configuration example

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- ✅My pull request adheres to the code style of this project
- ✅My code requires changes to the documentation
- ✅I have updated the documentation as required
- ✅ All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
