### PR TITLE
fix: align CI Go version with go.mod to resolve build failures

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-    GO_VERSION: "~1.21"
+    GO_VERSION: "~1.24"
 
 jobs:
   build:


### PR DESCRIPTION
Fixes #792

## Problem

CI builds are failing across multiple PRs (#791, #790, #789) with the error:
```
golang.org/x/tools/internal/tokeninternal/tokeninternal.go:64:9: 
invalid array length -delta * delta (constant -256 of type int64)
```

## Root Cause

**Version mismatch:**
- `go.mod` specifies: `go 1.24.0` with `toolchain go1.24.5`
- `.github/workflows/test.yaml` was using: `GO_VERSION: "~1.21"`

The older Go 1.21 toolchain has incompatibilities with `golang.org/x/tools` versions pulled in by `controller-tools`, causing compile-time errors.

## Solution

Update `.github/workflows/test.yaml` to use Go ~1.24, aligning CI with the project's go.mod requirements.

## Changes

- Updated `GO_VERSION` from `~1.21` to `~1.24` in `.github/workflows/test.yaml`

## Testing

This PR should pass all CI checks now that the Go version is aligned. Once merged, it will unblock the other failing PRs.

## Impact

- ✅ Fixes build failures across all PRs
- ✅ Aligns CI with project's declared Go version
- ✅ No breaking changes to code or functionality