### PR TITLE
feat: add deploymentLabels and deploymentAnnotations to K8sGPT CRD

### DIFF
--- a/api/v1alpha1/k8sgpt_types.go
+++ b/api/v1alpha1/k8sgpt_types.go
@@ -174,6 +174,12 @@ type K8sGPTSpec struct {
 	// Define the kubeconfig the Deployment must use.
 	// If empty, the Deployment will use the ServiceAccount provided by Kubernetes itself.
 	Kubeconfig *SecretRef `json:"kubeconfig,omitempty"`
+	// DeploymentLabels allows adding custom labels to the K8sGPT Deployment for
+	// organizational tracking, monitoring, logging, and cost allocation purposes.
+	DeploymentLabels map[string]string `json:"deploymentLabels,omitempty"`
+	// DeploymentAnnotations allows adding custom annotations to the K8sGPT Deployment
+	// for integration with monitoring systems and other infrastructure components.
+	DeploymentAnnotations map[string]string `json:"deploymentAnnotations,omitempty"`
 	// PodLabels allows adding custom labels to the K8sGPT pods for organizational tracking,
 	// service mesh integration, and monitoring purposes.
 	PodLabels map[string]string `json:"podLabels,omitempty"`

--- a/pkg/resources/k8sgpt.go
+++ b/pkg/resources/k8sgpt.go
@@ -285,10 +285,30 @@ func GetDeployment(config v1alpha1.K8sGPT, outOfClusterMode bool, c client.Clien
 		}
 	}
 
+	// Merge default labels with custom deployment labels
+	deploymentLabels := map[string]string{
+		"app": config.Name,
+	}
+	if config.Spec.DeploymentLabels != nil {
+		for k, v := range config.Spec.DeploymentLabels {
+			deploymentLabels[k] = v
+		}
+	}
+
+	// Create deployment annotations if specified
+	deploymentAnnotations := make(map[string]string)
+	if config.Spec.DeploymentAnnotations != nil {
+		for k, v := range config.Spec.DeploymentAnnotations {
+			deploymentAnnotations[k] = v
+		}
+	}
+
 	deployment := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      config.Name,
 			Namespace: config.Namespace,
+			Labels:      deploymentLabels,
+			Annotations: deploymentAnnotations,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					Kind:               config.Kind,


### PR DESCRIPTION
## Summary

Adds `deploymentLabels` and `deploymentAnnotations` fields to the K8sGPT CRD spec, allowing custom labels and annotations to be applied to the operator-managed Deployment resource.

### Motivation

When multiple K8sGPT instances are deployed, users need to distinguish them for monitoring, logging, and cost allocation. The existing `podLabels`/`podAnnotations` only apply to the pod template, not the Deployment itself.

### Changes

- **`api/v1alpha1/k8sgpt_types.go`**: Added `DeploymentLabels` and `DeploymentAnnotations` fields to the K8sGPTSpec
- **`pkg/resources/k8sgpt.go`**: Propagate custom labels/annotations to the Deployment's ObjectMeta (merged with the default `app` label)

### Usage

```yaml
apiVersion: core.k8sgpt.ai/v1alpha1
kind: K8sGPT
metadata:
  name: k8sgpt-sample
spec:
  deploymentLabels:
    team: platform
    cost-center: engineering
  deploymentAnnotations:
    monitoring.example.com/enabled: "true"
  # ... other fields
```

### Testing

- `go build ./...` passes ✅
- No breaking changes — new optional fields only

Fixes #689

Signed-off-by: Three Foxes (in a Trenchcoat) <threefoxes53235@gmail.com>