### PR TITLE
chore: migrate to Go 1.26 and controller-gen v0.21.0

### DIFF
--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -13,7 +13,7 @@ on:
       - "**.md"
 
 env:
-  GO_VERSION: "~1.21"
+  GO_VERSION: "~1.26"
   IMAGE_NAME: "k8sgpt-operator"
 defaults:
   run:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 env:
   # Default minimum version of Go to support.
-  DEFAULT_GO_VERSION: 1.19
+  DEFAULT_GO_VERSION: 1.26
   REGISTRY: ghcr.io
   GITHUB_PAGES_BRANCH: gh_pages
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-    GO_VERSION: "~1.24"
+    GO_VERSION: "~1.26"
 
 jobs:
   build:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.24-alpine3.21 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine3.23 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.16.0
+CONTROLLER_TOOLS_VERSION ?= v0.21.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -432,6 +432,20 @@ func (in *K8sGPTSpec) DeepCopyInto(out *K8sGPTSpec) {
 		*out = new(SecretRef)
 		**out = **in
 	}
+	if in.DeploymentLabels != nil {
+		in, out := &in.DeploymentLabels, &out.DeploymentLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.DeploymentAnnotations != nil {
+		in, out := &in.DeploymentAnnotations, &out.DeploymentAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.PodLabels != nil {
 		in, out := &in.PodLabels, &out.PodLabels
 		*out = make(map[string]string, len(*in))

--- a/config/crd/bases/core.k8sgpt.ai_k8sgpts.yaml
+++ b/config/crd/bases/core.k8sgpt.ai_k8sgpts.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: k8sgpts.core.k8sgpt.ai
 spec:
   group: core.k8sgpt.ai
@@ -352,6 +352,20 @@ spec:
                       type: string
                   type: object
                 type: array
+              deploymentAnnotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  DeploymentAnnotations allows adding custom annotations to the K8sGPT Deployment
+                  for integration with monitoring systems and other infrastructure components.
+                type: object
+              deploymentLabels:
+                additionalProperties:
+                  type: string
+                description: |-
+                  DeploymentLabels allows adding custom labels to the K8sGPT Deployment for
+                  organizational tracking, monitoring, logging, and cost allocation purposes.
+                type: object
               extraOptions:
                 properties:
                   backstage:

--- a/config/crd/bases/core.k8sgpt.ai_mutations.yaml
+++ b/config/crd/bases/core.k8sgpt.ai_mutations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: mutations.core.k8sgpt.ai
 spec:
   group: core.k8sgpt.ai

--- a/config/crd/bases/core.k8sgpt.ai_results.yaml
+++ b/config/crd/bases/core.k8sgpt.ai_results.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: results.core.k8sgpt.ai
 spec:
   group: core.k8sgpt.ai

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/k8sgpt-ai/k8sgpt-operator
 
-go 1.24.0
+go 1.26.3
 
-toolchain go1.24.5
+toolchain go1.26.5
 
 require (
 	buf.build/gen/go/k8sgpt-ai/k8sgpt/grpc/go v1.5.1-20241118152629-1379a5a1889d.2


### PR DESCRIPTION
## Why

Upstream k8s.io dependencies have moved past Go 1.24, so Renovate PRs touching them drag the `go` directive forward and break CI. Companion to k8sgpt-ai/k8sgpt#1689, which unblocks the pile-up of red Renovate PRs on the CLI repo.

## What

- **go.mod**: `go 1.26.3`, `toolchain go1.26.5` — matches what Renovate's rebases generate
- **controller-gen**: v0.16.0 → v0.21.0 — v0.16.0 fails to compile under go1.26 (`invalid array length -delta * delta` in its x/tools v0.24.0 dependency), so `make test`/`make manifests` would break in CI the moment Go moves
- **Regenerated CRDs + deepcopy** with v0.21.0. Note: this also picks up `deploymentLabels`/`deploymentAnnotations` schema and deepcopy entries that existed in the API types but were never regenerated — the generated files on main were stale
- **CI workflows**: `test.yaml` Go `~1.24` → `~1.26`; also refreshed the stale `release.yaml` (1.19) and `build_container.yaml` (~1.21) env pins
- **Dockerfile**: builder `golang:1.24-alpine3.21` → `golang:1.26-alpine3.23` (1.26 is not published for alpine3.21; tag verified on Docker Hub)

## Verification

- `go build ./...` — passes on go1.26
- `make test` (envtest suite included) — exit 0, all packages pass
- `make manifests generate` — diff limited to the version annotation and the stale-schema catch-up above

🤖 Generated with [Claude Code](https://claude.com/claude-code)