### PR TITLE
refactor: remove textual remediation similarity

### DIFF
--- a/AUTO_REMEDIATION.md
+++ b/AUTO_REMEDIATION.md
@@ -18,15 +18,12 @@ spec:
   ai:
     autoRemediation:
       enabled: true
-      similarityRequirement: "90"
       resources:
         - Pod
         - Deployment
 ```
 
 `enabled` turns the feature on. `resources` is an exact allowlist of resource selectors. Use a legacy `Kind` (`Deployment`), `group/Kind` (`apps/Deployment`), or an exact `group/version/Kind` (`apps/v1/Deployment`, `v1/ConfigMap`). A selector lets the operator create a proposal; it does not grant mutation rights. The matching GVK must also have a registered policy.
-
-`similarityRequirement` is retained for CRD compatibility but no longer authorizes execution. Whole-manifest textual similarity is not a safety proof: YAML formatting, field order, generated fields, and unrelated changes can affect it.
 
 ## Safety model and lifecycle
 

--- a/api/v1alpha1/k8sgpt_types.go
+++ b/api/v1alpha1/k8sgpt_types.go
@@ -100,10 +100,6 @@ type BackOff struct {
 type AutoRemediation struct {
 	// +kubebuilder:default:=false
 	Enabled bool `json:"enabled"`
-	// Deprecated: textual similarity is retained for API compatibility only.
-	// Execution is authorized by the deterministic remediation policy.
-	// +kubebuilder:default="90"
-	SimilarityRequirement string `json:"similarityRequirement"`
 	// Resources is an exact allowlist of target resource selectors. Use Kind for
 	// legacy matching, group/Kind (for example apps/Deployment), or
 	// group/version/Kind (for example apps/v1/Deployment or v1/ConfigMap).

--- a/api/v1alpha1/mutation_types.go
+++ b/api/v1alpha1/mutation_types.go
@@ -28,7 +28,6 @@ import (
 type MutationSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
-	SimilarityScore     string                 `json:"similarityScore,omitempty"`
 	ResourceGVK         string                 `json:"resourceGVK,omitempty"`
 	ResourceRef         corev1.ObjectReference `json:"resource,omitempty"`
 	ResultRef           corev1.ObjectReference `json:"result,omitempty"`
@@ -49,9 +48,8 @@ type MutationStatus struct {
 
 // +kubebuilder:object:root=true
 
-// Display in wide format the autoremediationphase status and similarity score
+// Display the autoremediation phase in wide format.
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.message",description="Updates of the autoremediation phase"
-// +kubebuilder:printcolumn:name="Similarity Score",type="string",JSONPath=".spec.similarityScore",description="The similarity score of the autoremediation"
 // Mutation is the Schema for the mutations API.
 type Mutation struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/chart/operator/crds/k8sgpt-crd.yaml
+++ b/chart/operator/crds/k8sgpt-crd.yaml
@@ -62,16 +62,9 @@ spec:
                         items:
                           type: string
                         type: array
-                      similarityRequirement:
-                        default: "90"
-                        description: |-
-                          Deprecated: textual similarity is retained for API compatibility only.
-                          Execution is authorized by the deterministic remediation policy.
-                        type: string
                     required:
                     - enabled
                     - resources
-                    - similarityRequirement
                     type: object
                   azureAPIType:
                     enum:

--- a/chart/operator/crds/mutation-crd.yaml
+++ b/chart/operator/crds/mutation-crd.yaml
@@ -19,15 +19,11 @@ spec:
       jsonPath: .status.message
       name: State
       type: string
-    - description: The similarity score of the autoremediation
-      jsonPath: .spec.similarityScore
-      name: Similarity Score
-      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
-          Display in wide format the autoremediationphase status and similarity score
+          Display the autoremediation phase in wide format.
           Mutation is the Schema for the mutations API.
         properties:
           apiVersion:
@@ -142,11 +138,6 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              similarityScore:
-                description: |-
-                  INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                  Important: Run "make" to regenerate code after modifying this file
-                type: string
               targetConfiguration:
                 type: string
             type: object

--- a/config/crd/bases/core.k8sgpt.ai_k8sgpts.yaml
+++ b/config/crd/bases/core.k8sgpt.ai_k8sgpts.yaml
@@ -62,16 +62,9 @@ spec:
                         items:
                           type: string
                         type: array
-                      similarityRequirement:
-                        default: "90"
-                        description: |-
-                          Deprecated: textual similarity is retained for API compatibility only.
-                          Execution is authorized by the deterministic remediation policy.
-                        type: string
                     required:
                     - enabled
                     - resources
-                    - similarityRequirement
                     type: object
                   azureAPIType:
                     enum:

--- a/config/crd/bases/core.k8sgpt.ai_mutations.yaml
+++ b/config/crd/bases/core.k8sgpt.ai_mutations.yaml
@@ -19,15 +19,11 @@ spec:
       jsonPath: .status.message
       name: State
       type: string
-    - description: The similarity score of the autoremediation
-      jsonPath: .spec.similarityScore
-      name: Similarity Score
-      type: string
     name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-
-          Display in wide format the autoremediationphase status and similarity score
+          Display the autoremediation phase in wide format.
           Mutation is the Schema for the mutations API.
         properties:
           apiVersion:
@@ -97,6 +93,9 @@ spec:
                 type: object
                 x-kubernetes-map-type: atomic
               resourceGVK:
+                description: |-
+                  INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "make" to regenerate code after modifying this file
                 type: string
               result:
                 description: ObjectReference contains enough information to let you
@@ -142,11 +141,6 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              similarityScore:
-                description: |-
-                  INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                  Important: Run "make" to regenerate code after modifying this file
-                type: string
               targetConfiguration:
                 type: string
             type: object

--- a/config/samples/autoremediation/valid_k8sgpt_remediation_deepseek.yaml
+++ b/config/samples/autoremediation/valid_k8sgpt_remediation_deepseek.yaml
@@ -6,7 +6,6 @@ spec:
   ai:
     autoRemediation:
       enabled: true
-      similarityRequirement: "90"
       resources:
         - Pod
         - Deployment

--- a/config/samples/autoremediation/valid_k8sgpt_remediation_sample.yaml
+++ b/config/samples/autoremediation/valid_k8sgpt_remediation_sample.yaml
@@ -6,7 +6,6 @@ spec:
   ai:
     autoRemediation:
       enabled: true
-      similarityRequirement: "90"
       resources:
         - Pod
         - Deployment

--- a/config/samples/autoremediation/valid_k8sgpt_remediation_with_interplex.yaml
+++ b/config/samples/autoremediation/valid_k8sgpt_remediation_with_interplex.yaml
@@ -6,7 +6,6 @@ spec:
   ai:
     autoRemediation:
       enabled: true
-      similarityRequirement: "90"
       resources:
         - Pod
         - Deployment

--- a/config/samples/exhaustive_sample.yaml
+++ b/config/samples/exhaustive_sample.yaml
@@ -48,7 +48,6 @@ spec:
   ai:                          # AI configuration (required)
     autoRemediation:           # Automatic remediation settings
       enabled: <boolean>        # Enable/disable auto-remediation
-      similarityRequirement: <percentage-string> # Textual similarity percentage (e.g., "90")
       resources:                # Supported resource kinds to auto-remediate
         - Pod
         - Deployment

--- a/demo.sh
+++ b/demo.sh
@@ -50,7 +50,6 @@ spec:
   ai:
     autoRemediation:
       enabled: true
-      similarityRequirement: "90"
       resources:
         - Pod
         - Deployment

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ toolchain go1.26.5
 require (
 	buf.build/gen/go/k8sgpt-ai/k8sgpt/grpc/go v1.5.1-20241118152629-1379a5a1889d.2
 	buf.build/gen/go/k8sgpt-ai/k8sgpt/protocolbuffers/go v1.36.6-20241118152629-1379a5a1889d.1
-	github.com/agnivade/levenshtein v1.2.1
 	github.com/cloudevents/sdk-go/v2 v2.16.1
 	github.com/go-logr/logr v1.4.3
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -6,10 +6,6 @@ github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
-github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
-github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0 h1:jfIu9sQUG6Ig+0+Ap1h4unLjW6YQJpKZVmUzxsD4E/Q=
-github.com/arbovm/levenshtein v0.0.0-20160628152529-48b4e1c0c4d0/go.mod h1:t2tdKJDJF9BV14lnkjHmOQgcvEKgtqs5a1N3LNdJhGE=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -30,8 +26,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7cNTs5R6Hk4V2lcmLz2NsG2VnInyNo=
-github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/emicklei/go-restful/v3 v3.11.0 h1:rAQeMHw1c7zTmncogyy8VvRZwtkmkZ4FxERmMY4rD+g=
 github.com/emicklei/go-restful/v3 v3.11.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=

--- a/internal/controller/mutation/mutation_controller.go
+++ b/internal/controller/mutation/mutation_controller.go
@@ -158,12 +158,8 @@ func (r *MutationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			}
 			return ctrl.Result{}, nil
 		}
-		// compute similarity score
-		score := util.SimilarityScore(mutation.Spec.OriginConfiguration, proposal)
-		mutationControllerLog.Info("Similarity score", "score", score)
 		mutationControllerLog.Info("Got mutation targetConfiguration for", "mutation", mutation.Name)
 		mutation.Spec.TargetConfiguration = proposal
-		mutation.Spec.SimilarityScore = fmt.Sprintf("%f", score)
 		mutation.Status.Phase = corev1alpha1.AutoRemediationPhaseInProgress
 		mutation.Status.Message = "In Progress"
 		if err := r.Client.Update(ctx, &mutation); err != nil {
@@ -182,8 +178,7 @@ func (r *MutationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			mutationControllerLog.Info("Target configuration is not set, this shouldn't occur at this phase", "mutation", mutation.Name)
 			return ctrl.Result{RequeueAfter: util.ErrorRequeueTime}, nil
 		}
-		// Similarity is recorded for backwards compatibility only. Authorization
-		// is determined by the semantic policy gate in ResourceToExecution.
+		// Authorization is determined by the semantic policy gate in ResourceToExecution.
 		// Convert the spec.targetConfiguration to an Object
 		// 1. Get the GVK from the Kind string
 		obj, err := util.FromConfig(util.FromObjectConfig{

--- a/internal/controller/util/compare.go
+++ b/internal/controller/util/compare.go
@@ -1,9 +1,5 @@
 package util
 
-import (
-	"github.com/agnivade/levenshtein"
-)
-
 func IsStringInSlice(a string, b []string) bool {
 	if len(b) == 0 {
 		return false
@@ -14,14 +10,4 @@ func IsStringInSlice(a string, b []string) bool {
 		}
 	}
 	return false
-}
-
-func SimilarityScore(text1 string, text2 string) float64 {
-	// Calculate the Levenshtein distance.
-	distance := levenshtein.ComputeDistance(text1, text2)
-	// Calculate the maximum length between the two strings.
-	maxLength := max(len(text1), len(text2))
-	// Calculate the similarity score as a percentage.
-	similarity := (1.0 - float64(distance)/float64(maxLength)) * 100.0
-	return similarity
 }


### PR DESCRIPTION
## Summary
- remove textual similarity configuration and mutation score from the API
- remove the Levenshtein dependency and unused runtime calculation
- update generated and Helm CRDs, documentation, demo, and all samples

## Validation
- `make test`
- `helm lint chart/operator`
- `make e2e-remediation` (fresh Kind cluster; invalid-image Deployment remediated and rollout verified)