### PR TITLE
feat: add controllerManager.kubeRbacProxy.enabled flag to disable proxy sidecar

### DIFF
--- a/chart/operator/README.md
+++ b/chart/operator/README.md
@@ -9,6 +9,27 @@ Automatic SRE Superpowers within your Kubernetes cluster
 
 The following table lists the configurable parameters of the K8sgpt-operator chart and their default values.
 
+## Metrics Configuration
+
+### kube-rbac-proxy
+
+By default, the operator deploys a `kube-rbac-proxy` sidecar container to protect the metrics endpoint with Kubernetes RBAC authorization and HTTPS encryption.
+
+#### Disabling kube-rbac-proxy
+
+You can disable the proxy to expose metrics directly via HTTP:
+
+```yaml
+controllerManager:
+  kubeRbacProxy:
+    enabled: false
+```
+
+When disabled, the manager exposes /metrics directly over HTTP on port
+8080 without Kubernetes RBAC authorization. Ensure access is protected by
+appropriate network policies, service mesh policies, or other infrastructure
+controls.
+
 <!---x-release-please-start-version-->
 | Parameter                | Description             | Default                                                                       |
 | ------------------------ | ----------------------- |-------------------------------------------------------------------------------|
@@ -19,6 +40,7 @@ The following table lists the configurable parameters of the K8sgpt-operator cha
 | `grafanaDashboard.folder.name` |  | `"ai"`                                                                        |
 | `grafanaDashboard.label.key` |  | `"grafana_dashboard"`                                                         |
 | `grafanaDashboard.label.value` |  | `"1"`                                                                         |
+| `controllerManager.kubeRbacProxy.enabled` | Enable kube-rbac-proxy for RBAC-protected HTTPS metrics | `true` |
 | `controllerManager.kubeRbacProxy.containerSecurityContext.allowPrivilegeEscalation` |  | `false`                                                                       |
 | `controllerManager.kubeRbacProxy.containerSecurityContext.capabilities.drop` |  | `["ALL"]`                                                                     |
 | `controllerManager.kubeRbacProxy.image.repository` |  | `"gcr.io/kubebuilder/kube-rbac-proxy"`                                        |

--- a/chart/operator/templates/controller-manager-metrics-monitor.yaml
+++ b/chart/operator/templates/controller-manager-metrics-monitor.yaml
@@ -20,12 +20,18 @@ spec:
     - {{ include "k8sgpt-operator.namespace" . }}
   {{- end }}
   endpoints:
+  {{- if .Values.controllerManager.kubeRbacProxy.enabled }}
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     path: /metrics
     port: https
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
+  {{- else }}
+  - path: /metrics
+    port: http
+    scheme: http
+  {{- end }}
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/chart/operator/templates/deployment.yaml
+++ b/chart/operator/templates/deployment.yaml
@@ -59,6 +59,7 @@ spec:
                 values:
                 - linux
       containers:
+      {{- if .Values.controllerManager.kubeRbacProxy.enabled }}
       - args:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/
@@ -78,9 +79,14 @@ spec:
           10 }}
         securityContext: {{- toYaml .Values.controllerManager.kubeRbacProxy.containerSecurityContext
           | nindent 10 }}
+      {{- end }}
       - args:
         - --health-probe-bind-address=:8081
+      {{- if .Values.controllerManager.kubeRbacProxy.enabled }}
         - --metrics-bind-address=127.0.0.1:8080
+      {{- else }}
+        - --metrics-bind-address=:8080
+      {{- end }}
         - --leader-elect
       {{- if .Values.controllerManager.manager.enableResultLogging }}
         - --enable-result-logging
@@ -113,6 +119,12 @@ spec:
           }}
         securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
           | nindent 10 }}
+      {{- if not .Values.controllerManager.kubeRbacProxy.enabled }}
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+      {{- end }}
       {{- if .Values.controllerManager.podSecurityContext }}
       securityContext:
       {{- toYaml .Values.controllerManager.podSecurityContext | nindent 8 }}

--- a/chart/operator/templates/metrics-reader-rbac.yaml
+++ b/chart/operator/templates/metrics-reader-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controllerManager.kubeRbacProxy.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -12,3 +13,4 @@ rules:
   - /metrics
   verbs:
   - get
+{{- end }}

--- a/chart/operator/templates/metrics-service.yaml
+++ b/chart/operator/templates/metrics-service.yaml
@@ -3,7 +3,11 @@ kind: Service
 metadata:
   name: {{ include "chart.fullname" . | trunc 20}}-controller-manager-metrics-service
   labels:
+    {{- if .Values.controllerManager.kubeRbacProxy.enabled }}
     app.kubernetes.io/component: kube-rbac-proxy
+    {{- else }}
+    app.kubernetes.io/component: metrics
+    {{- end }}
     app.kubernetes.io/created-by: k8sgpt-operator
     app.kubernetes.io/part-of: k8sgpt-operator
     control-plane: controller-manager
@@ -14,4 +18,11 @@ spec:
     control-plane: controller-manager
   {{- include "chart.selectorLabels" . | nindent 4 }}
   ports:
-	{{- .Values.metricsService.ports | toYaml | nindent 2 -}}
+  {{- if .Values.controllerManager.kubeRbacProxy.enabled }}
+  {{- .Values.metricsService.ports | toYaml | nindent 2 }}
+  {{- else }}
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: metrics
+  {{- end }}

--- a/chart/operator/templates/proxy-rbac.yaml
+++ b/chart/operator/templates/proxy-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.controllerManager.kubeRbacProxy.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -38,3 +39,4 @@ subjects:
 - kind: ServiceAccount
   name: '{{ include "chart.fullname" . }}-controller-manager'
   namespace: '{{ .Release.Namespace }}'
+{{- end }}

--- a/chart/operator/values.yaml
+++ b/chart/operator/values.yaml
@@ -34,6 +34,9 @@ controllerManager:
   # Additional annotations to add to the controller manager deployment
   annotations: {}
   kubeRbacProxy:
+    ## When enabled (default), deploys kube-rbac-proxy sidecar for HTTPS and RBAC-protected metrics.
+    ## Set to false to expose metrics directly via HTTP without RBAC enforcement.
+    enabled: true
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:


### PR DESCRIPTION
Closes #817

## 📑 Description

Adds a Helm chart option to disable `kube-rbac-proxy` for the metrics endpoint.

* Adds `controllerManager.kubeRbacProxy.enabled`, enabled by default
* When disabled, metrics are exposed directly over HTTP on port `8080`
* Proxy-related RBAC resources are not created
* Updates the ServiceMonitor and metrics Service accordingly
* Keeps the existing secure behavior unchanged by default

## ✅ Checks

* [x] My pull request adheres to the code style of this project
* [x] My code requires changes to the documentation
* [x] I have updated the documentation as required
* [ ] All the tests have passed

## ℹ Additional Information

Disabling `kube-rbac-proxy` removes Kubernetes RBAC protection from the metrics endpoint. Users should secure access through network policies, service mesh policies, or other infrastructure controls.

Verified locally with `helm lint` and `helm template` for both proxy-enabled and proxy-disabled configurations.

